### PR TITLE
chore: remove terraform-docs

### DIFF
--- a/.terraform-docs.yml
+++ b/.terraform-docs.yml
@@ -1,5 +1,0 @@
-# https://terraform-docs.io/user-guide/configuration/
-formatter: "markdown table"
-output:
-  file: README.md
-  mode: inject

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,1 @@
 SHELL := /bin/bash
-ROOT := $$(git rev-parse --show-toplevel)
-
-.PHONY: docs
-
-docs:
-	@terraform-docs markdown table --output-file "$(ROOT)/README.md" --output-mode inject "$(ROOT)"


### PR DESCRIPTION
Rolls out the reviewed changes from https://github.com/isovalent/terraform-aws-k8s-base/pull/109 to remove terraform-docs from CI and local automation.